### PR TITLE
feat(collision): implement hit sound effect on collision

### DIFF
--- a/features/collision.feature
+++ b/features/collision.feature
@@ -65,7 +65,6 @@ Feature: Collision Detection
       | 100    | 120    | 180    | alive | bird in gap (safe zone)     |
       | 100    | 170    | 200    | alive | bird far right of pipe      |
 
-  @skip
   Scenario: Hit sound plays when bird collides with pipe
     Given a pipe is created at position (200, 0)
     When the game advances until the bird collides with the pipe

--- a/features/steps/collision.steps.ts
+++ b/features/steps/collision.steps.ts
@@ -166,3 +166,7 @@ Then("the game should stop completely", (world: GameWorld) => {
   const birdAfter = stateAfter.entities["bird"] as Bird;
   expect(Math.abs(birdAfter.position.y - yBefore)).toBeLessThan(1);
 });
+
+Then("the hit sound effect should play", (world: GameWorld) => {
+  expect(world.audioAdapter.playedSounds).toContain("hit");
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,10 @@ try {
     import.meta.url,
   ).href;
   await audioAdapter.preloadSound("point", pointAudioUrl);
+
+  const hitAudioUrl = new URL("./assets/soundEffects/hit.ogg", import.meta.url)
+    .href;
+  await audioAdapter.preloadSound("hit", hitAudioUrl);
 } catch (error) {
   console.warn("Failed to preload sound effects:", error);
   // Continue game initialization even if audio fails

--- a/src/systems/AudioSystem.ts
+++ b/src/systems/AudioSystem.ts
@@ -1,4 +1,4 @@
-import { POINT_SOUND, WING_FLAP_SOUND } from "@/constants";
+import { HIT_SOUND, POINT_SOUND, WING_FLAP_SOUND } from "@/constants";
 import type { Command, System } from "@/engine/engine";
 import { GameEventType, type Event } from "@/events";
 import type { AudioAdapter } from "@/systems/AudioAdapter";
@@ -22,6 +22,12 @@ export const AudioSystem = (adapter: AudioAdapter): System => {
     // This provides audio feedback for successful pipe navigation
     if (event.type === GameEventType.IncrementScore) {
       adapter.playSound(POINT_SOUND);
+    }
+
+    // Play hit sound when bird collides with pipe obstacles
+    // This provides audio feedback for collision events
+    if (event.type === GameEventType.BirdCollision) {
+      adapter.playSound(HIT_SOUND);
     }
 
     return [];


### PR DESCRIPTION
## 摘要

實作碰撞音效，當 Bird 撞到 Pipe 時播放 hit.ogg 音效。

## 變更說明

- 新增 HIT_SOUND 常數匯入到 AudioSystem
- 加入 BIRD_COLLISION 事件處理邏輯播放碰撞音效
- 新增測試步驟定義驗證音效播放
- 移除測試的 @skip 標記

## 設計遵循

- 符合 docs/design/system/audio_system.md 設計文件
- 只在撞到水管時播放音效（不在落地時播放）
- 使用 HIT_SOUND 常數（src/constants.ts）
- 遵循現有的 AudioSystem 模式

## 測試結果

- 所有測試通過 (56 passed, 1 skipped)
- TypeScript 型別檢查通過
- 生產建置成功

Closes #54
Related to #52, #53

🤖 Generated with [Claude Code](https://claude.ai/code)) | [Branch: claude/issue-54-20251208-1228](https://github.com/elct9620/poc-ai-dev-flappy-bird/tree/claude/issue-54-20251208-1228) | [View job run](https://github.com/elct9620/poc-ai-dev-flappy-bird/actions/runs/20028104262